### PR TITLE
feat: enhance stage module to support grass 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,9 @@
-# Changelog
-
-All notable changes to this project will be documented in this file.
-
-## [1.1.0](https://github.com/subhamay-bhattacharyya-tf/terraform-snowflake-stage/compare/v1.0.0...v1.1.0) (2026-02-18)
-
-### Features
-
-* convert to single-module repository layout for Snowflake stage ([4dafad8](https://github.com/subhamay-bhattacharyya-tf/terraform-snowflake-stage/commit/4dafad896ee512aa0b60d8babcb90f9298e47bbe))
-* **stages:** add directory table support for internal and external stages ([f2274c0](https://github.com/subhamay-bhattacharyya-tf/terraform-snowflake-stage/commit/f2274c049760b546dcac0c7fb9affe2d20530643))
-* **stages:** separate internal and external stage resources ([794fd09](https://github.com/subhamay-bhattacharyya-tf/terraform-snowflake-stage/commit/794fd09306c0ca6bbbfd120318275fa9a3c92b16))
-
 ## [unreleased]
+
+### 🚀 Features
+
+- Add grants support and convert to single-module repository layout
+## [1.1.0] - 2026-02-18
 
 ### 🚀 Features
 
@@ -34,6 +27,7 @@ All notable changes to this project will be documented in this file.
 - *(stages)* Remove unsupported cloud providers and simplify configuration
 - Update CHANGELOG.md [skip ci]
 - Update CHANGELOG.md [skip ci]
+- Update CHANGELOG.md [skip ci]
 
 ### 🎨 Styling
 
@@ -44,6 +38,7 @@ All notable changes to this project will be documented in this file.
 ### ⚙️ Miscellaneous Tasks
 
 - Upgrade Snowflake provider to 1.0.0 and standardize documentation
+- *(release)* Version 1.1.0 [skip ci]
 ## [1.0.0] - 2026-02-09
 
 ### 🚀 Features

--- a/README.md
+++ b/README.md
@@ -126,6 +126,41 @@ module "stages" {
 | storage_integration | string | null | Storage integration name for external stages |
 | directory_enabled | bool | false | Enable directory table for the stage |
 | comment | string | null | Description of the stage |
+| grants | list(object) | [] | List of role grants for the stage |
+
+### grants Object Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| role_name | string | Name of the account role to grant privileges to |
+| privileges | list(string) | List of privileges to grant (e.g., ["READ", "WRITE"]) |
+
+### Example with Grants
+
+```hcl
+module "stage" {
+  source = "github.com/subhamay-bhattacharyya-tf/terraform-snowflake-stage"
+
+  stage_configs = {
+    "my_stage" = {
+      name     = "MY_STAGE"
+      database = "MY_DATABASE"
+      schema   = "PUBLIC"
+      comment  = "Stage with role grants"
+      grants = [
+        {
+          role_name  = "DATA_ENGINEER"
+          privileges = ["READ", "WRITE"]
+        },
+        {
+          role_name  = "DATA_ANALYST"
+          privileges = ["READ"]
+        }
+      ]
+    }
+  }
+}
+```
 
 ### Stage Types
 

--- a/examples/external-stage/README.md
+++ b/examples/external-stage/README.md
@@ -6,10 +6,8 @@ This example demonstrates how to create external Snowflake stages using the snow
 
 External stages reference data files stored in external cloud storage locations:
 - AWS S3 (`s3://`)
-- Google Cloud Storage (`gcs://`)
-- Azure Blob Storage (`azure://`)
 
-External stages require either a storage integration or credentials for authentication.
+External stages require a storage integration for authentication.
 
 ## Usage
 
@@ -27,44 +25,16 @@ module "stage" {
       url                 = "s3://my-bucket/data/"
       storage_integration = "MY_S3_INTEGRATION"
       comment             = "External S3 stage"
-    }
-  }
-}
-```
-
-### GCS External Stage
-
-```hcl
-module "stage" {
-  source = "../../"
-
-  stage_configs = {
-    "gcs_stage" = {
-      name                = "MY_GCS_STAGE"
-      database            = "MY_DATABASE"
-      schema              = "PUBLIC"
-      url                 = "gcs://my-bucket/data/"
-      storage_integration = "MY_GCS_INTEGRATION"
-      comment             = "External GCS stage"
-    }
-  }
-}
-```
-
-### Azure External Stage
-
-```hcl
-module "stage" {
-  source = "../../"
-
-  stage_configs = {
-    "azure_stage" = {
-      name                = "MY_AZURE_STAGE"
-      database            = "MY_DATABASE"
-      schema              = "PUBLIC"
-      url                 = "azure://myaccount.blob.core.windows.net/container/path/"
-      storage_integration = "MY_AZURE_INTEGRATION"
-      comment             = "External Azure stage"
+      grants = [
+        {
+          role_name  = "DATA_ENGINEER"
+          privileges = ["READ", "WRITE"]
+        },
+        {
+          role_name  = "DATA_ANALYST"
+          privileges = ["READ"]
+        }
+      ]
     }
   }
 }

--- a/examples/external-stage/variables.tf
+++ b/examples/external-stage/variables.tf
@@ -14,6 +14,10 @@ variable "stage_configs" {
     storage_integration = optional(string, null)
     directory_enabled   = optional(bool, false)
     comment             = optional(string, null)
+    grants = optional(list(object({
+      role_name  = string
+      privileges = list(string)
+    })), [])
   }))
   default = {
     "my_s3_stage" = {

--- a/examples/internal-stage/README.md
+++ b/examples/internal-stage/README.md
@@ -21,6 +21,12 @@ module "stage" {
       database = "MY_DATABASE"
       schema   = "PUBLIC"
       comment  = "Internal stage for raw data files"
+      grants = [
+        {
+          role_name  = "DATA_ENGINEER"
+          privileges = ["READ", "WRITE"]
+        }
+      ]
     }
   }
 }

--- a/examples/internal-stage/variables.tf
+++ b/examples/internal-stage/variables.tf
@@ -14,6 +14,10 @@ variable "stage_configs" {
     storage_integration = optional(string, null)
     directory_enabled   = optional(bool, false)
     comment             = optional(string, null)
+    grants = optional(list(object({
+      role_name  = string
+      privileges = list(string)
+    })), [])
   }))
   default = {
     "my_internal_stage" = {

--- a/examples/multiple-stages/README.md
+++ b/examples/multiple-stages/README.md
@@ -25,6 +25,12 @@ module "stages" {
       database = "MY_DATABASE"
       schema   = "PUBLIC"
       comment  = "Internal stage for data loading"
+      grants = [
+        {
+          role_name  = "DATA_ENGINEER"
+          privileges = ["READ", "WRITE"]
+        }
+      ]
     }
     
     # External stage
@@ -35,6 +41,16 @@ module "stages" {
       url                 = "s3://my-bucket/data/"
       storage_integration = "MY_S3_INTEGRATION"
       comment             = "External S3 stage for data ingestion"
+      grants = [
+        {
+          role_name  = "DATA_ENGINEER"
+          privileges = ["READ"]
+        },
+        {
+          role_name  = "DATA_ANALYST"
+          privileges = ["READ"]
+        }
+      ]
     }
   }
 }

--- a/examples/multiple-stages/variables.tf
+++ b/examples/multiple-stages/variables.tf
@@ -14,6 +14,10 @@ variable "stage_configs" {
     storage_integration = optional(string, null)
     directory_enabled   = optional(bool, false)
     comment             = optional(string, null)
+    grants = optional(list(object({
+      role_name  = string
+      privileges = list(string)
+    })), [])
   }))
   default = {
     "internal_stage" = {
@@ -21,6 +25,12 @@ variable "stage_configs" {
       database = "MY_DATABASE"
       schema   = "PUBLIC"
       comment  = "Internal stage for data loading"
+      grants = [
+        {
+          role_name  = "DATA_ENGINEER"
+          privileges = ["READ", "WRITE"]
+        }
+      ]
     }
     "external_stage" = {
       name                = "MY_S3_STAGE"
@@ -29,6 +39,16 @@ variable "stage_configs" {
       url                 = "s3://my-bucket/data/"
       storage_integration = "MY_S3_INTEGRATION"
       comment             = "External S3 stage for data ingestion"
+      grants = [
+        {
+          role_name  = "DATA_ENGINEER"
+          privileges = ["READ"]
+        },
+        {
+          role_name  = "DATA_ANALYST"
+          privileges = ["READ"]
+        }
+      ]
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -14,6 +14,10 @@ variable "stage_configs" {
     storage_integration = optional(string, null)
     directory_enabled   = optional(bool, false)
     comment             = optional(string, null)
+    grants = optional(list(object({
+      role_name  = string
+      privileges = list(string)
+    })), [])
   }))
   default = {}
 


### PR DESCRIPTION
This pull request introduces grants support for Snowflake stages and updates documentation and examples to reflect this new feature. The most important changes are the addition of a `grants` property to stage configurations, implementation of resource logic to apply grants, and improvements to documentation and examples.

### Grants support for stages

* Added a `grants` property to the `stage_configs` variable in `variables.tf` and all example `variables.tf` files, allowing users to specify a list of role grants for each stage. Each grant includes a `role_name` and a list of `privileges`. [[1]](diffhunk://#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288eR17-R20) [[2]](diffhunk://#diff-77fdb8aa18084e8a6d4ecb76d68e1fec578a20d73326d41b7ebcf4072024508aR17-R20) [[3]](diffhunk://#diff-02102ef806323994a3ca328dd397594b195c4d0a20f7e3d09602a11ee80b4845R17-R20) [[4]](diffhunk://#diff-a398799c72f50a7af4fd90cb94789f43b792776606d4137d9da8da2029e10c0aR17-R33)
* Implemented a new resource `snowflake_grant_privileges_to_account_role.stage_grants` in `main.tf` to grant specified privileges to account roles on stages, supporting both internal and external stages.

### Documentation updates

* Updated `README.md` to document the new `grants` property, its object structure, and provided an example usage.
* Revised example `README.md` files for internal, external, and multiple stages to demonstrate how to use the `grants` property in stage configurations. [[1]](diffhunk://#diff-2ab468463e1040c93d35284d32773e1c7d5551ac49284ee1f4c0f9c220174bbcR24-R29) [[2]](diffhunk://#diff-eaeb33c3743df31d16b0393dd7265500c8c90e977ae3089ddf73dd4043fa1f3cR28-R37) [[3]](diffhunk://#diff-629931730649ef1064ea2c1f0c66c61f2c30223ca4e6810d5199d2c70ce52ed4R28-R33) [[4]](diffhunk://#diff-629931730649ef1064ea2c1f0c66c61f2c30223ca4e6810d5199d2c70ce52ed4R44-R53)

### Example and provider cleanup

* Removed unsupported cloud provider examples (GCS and Azure) from `examples/external-stage/README.md`, clarifying that only S3 is supported for external stages.

### Changelog updates

* Updated `CHANGELOG.md` to document the addition of grants support and other release notes. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL1-R6) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR30) [[3]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR41)